### PR TITLE
fix(core): change RGBA to NRGBA in gradient interpolation

### DIFF
--- a/internal/core/gradient.go
+++ b/internal/core/gradient.go
@@ -235,7 +235,7 @@ func colorLerp(c0, c1 color.Color, t float64) color.Color {
 	r0, g0, b0, a0 := c0.RGBA()
 	r1, g1, b1, a1 := c1.RGBA()
 
-	return color.RGBA{
+	return color.NRGBA{
 		lerp(r0, r1, t),
 		lerp(g0, g1, t),
 		lerp(b0, b1, t),

--- a/internal/core/gradient_test.go
+++ b/internal/core/gradient_test.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestGradientWithAlpha(t *testing.T) {
+	dc := NewContext(200, 100)
+
+	grad := NewLinearGradient(0, 0, 180, 0)
+	grad.AddColorStop(0, color.RGBA{255, 0, 0, 200})
+	grad.AddColorStop(1, color.RGBA{0, 0, 255, 100})
+
+	dc.SetFillStyle(grad)
+	dc.DrawRectangle(20, 20, 160, 60)
+	dc.Fill()
+
+	dc.SavePNG("out.png")
+}


### PR DESCRIPTION
- This change improves color representation and ensures consistent alpha blending